### PR TITLE
Fix directory removal in FilesStore

### DIFF
--- a/app/lib/stores/files.ts
+++ b/app/lib/stores/files.ts
@@ -138,8 +138,8 @@ export class FilesStore {
         case 'remove_dir': {
           this.files.setKey(sanitizedPath, undefined);
 
-          for (const [direntPath] of Object.entries(this.files)) {
-            if (direntPath.startsWith(sanitizedPath)) {
+          for (const [direntPath] of Object.entries(this.files.get())) {
+            if (direntPath.startsWith(`${sanitizedPath}/`)) {
               this.files.setKey(direntPath, undefined);
             }
           }


### PR DESCRIPTION
## Summary
- fix FileStore directory deletion handling by iterating over `this.files.get()`
- ensure only subpaths of the removed directory are deleted

## Testing
- `pnpm test` *(fails: Error when performing the request to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685575e6afa4832eb91af116c12695f0